### PR TITLE
Update EIP-7432: Add Approval Interface

### DIFF
--- a/EIPS/eip-7432.md
+++ b/EIPS/eip-7432.md
@@ -80,12 +80,10 @@ interface IERC7432 /* is ERC165 */ {
 
     /// @notice Emitted when a user is approved to manage any role on behalf of another user.
     /// @param _tokenAddress The token address.
-    /// @param _approver The user approving the operator.
     /// @param _operator The user approved to grant and revoke roles.
     /// @param _isApproved The approval status.
     event RoleApprovalForAll(
         address indexed _tokenAddress,
-        address indexed _approver,
         address indexed _operator,
         bool _isApproved
     );
@@ -93,13 +91,11 @@ interface IERC7432 /* is ERC165 */ {
     /// @notice Emitted when a user is approved to manage the roles of an NFT on behalf of another user.
     /// @param _tokenAddress The token address.
     /// @param _tokenId The token identifier.
-    /// @param _approver The user approving the operator.
     /// @param _operator The user approved to grant and revoke roles.
     /// @param _isApproved The approval status.
     event RoleApproval(
         address indexed _tokenAddress,
         uint256 indexed _tokenId,
-        address indexed _approver,
         address _operator,
         bool _isApproved
     );

--- a/assets/eip-7432/ERC7432.sol
+++ b/assets/eip-7432/ERC7432.sol
@@ -11,7 +11,7 @@ contract ERC7432 is IERC7432 {
         public roleAssignments;
 
     // grantor => tokenAddress => tokenId => role => grantee
-    mapping(address => mapping(address => mapping(uint256 => mapping(bytes32 => address)))) public latestGrantee;
+    mapping(address => mapping(address => mapping(uint256 => mapping(bytes32 => address)))) public latestGrantees;
 
     // grantor => tokenAddress => tokenId => operator => isApproved
     mapping(address => mapping(address => mapping(uint256 => mapping(address => bool)))) public tokenIdApprovals;
@@ -66,7 +66,7 @@ contract ERC7432 is IERC7432 {
         bytes calldata _data
     ) internal validExpirationDate(_expirationDate) {
         roleAssignments[_grantor][_grantee][_tokenAddress][_tokenId][_role] = RoleData(_expirationDate, _data);
-        latestGrantee[_grantor][_tokenAddress][_tokenId][_role] = _grantee;
+        latestGrantees[_grantor][_tokenAddress][_tokenId][_role] = _grantee;
         emit RoleGranted( _role, _tokenAddress, _tokenId, _grantor, _grantee, _expirationDate, _data);
     }
 
@@ -92,7 +92,7 @@ contract ERC7432 is IERC7432 {
         address _grantee
     ) internal {
         delete roleAssignments[_revoker][_grantee][_tokenAddress][_tokenId][_role];
-        delete latestGrantee[_revoker][_tokenAddress][_tokenId][_role];
+        delete latestGrantees[_revoker][_tokenAddress][_tokenId][_role];
         emit RoleRevoked(_role, _tokenAddress, _tokenId, _revoker, _grantee);
     }
 
@@ -113,7 +113,7 @@ contract ERC7432 is IERC7432 {
         address _grantor,
         address _grantee
     ) external view returns (bool) {
-        return  latestGrantee[_grantor][_tokenAddress][_tokenId][_role] == _grantee && roleAssignments[_grantor][_grantee][_tokenAddress][_tokenId][_role].expirationDate >
+        return  latestGrantees[_grantor][_tokenAddress][_tokenId][_role] == _grantee && roleAssignments[_grantor][_grantee][_tokenAddress][_tokenId][_role].expirationDate >
             block.timestamp;
     }
 
@@ -149,7 +149,7 @@ contract ERC7432 is IERC7432 {
         bool _isApproved
     ) external override {
         tokenApprovals[msg.sender][_tokenAddress][_operator] = _isApproved;
-        emit RoleApprovalForAll(msg.sender, _tokenAddress, _operator, _isApproved);
+        emit RoleApprovalForAll(_tokenAddress, _operator, _isApproved);
     }
 
     function approveRole(
@@ -159,7 +159,7 @@ contract ERC7432 is IERC7432 {
         bool _approved
     ) external override {
         tokenIdApprovals[msg.sender][_tokenAddress][_tokenId][_operator] = _approved;
-        emit RoleApproval( _tokenAddress, _tokenId, msg.sender, _operator, _approved);
+        emit RoleApproval( _tokenAddress, _tokenId, _operator, _approved);
     }
 
     function isRoleApprovedForAll(

--- a/assets/eip-7432/ERC7432.sol
+++ b/assets/eip-7432/ERC7432.sol
@@ -159,7 +159,7 @@ contract ERC7432 is IERC7432 {
         bool _approved
     ) external override {
         tokenIdApprovals[msg.sender][_tokenAddress][_tokenId][_operator] = _approved;
-        emit RoleApproval( _tokenAddress, _tokenId, _operator, _approved);
+        emit RoleApproval(_tokenAddress, _tokenId, _operator, _approved);
     }
 
     function isRoleApprovedForAll(

--- a/assets/eip-7432/interfaces/IERC7432.sol
+++ b/assets/eip-7432/interfaces/IERC7432.sol
@@ -50,12 +50,10 @@ interface IERC7432 is IERC165 {
 
     /// @notice Emitted when a user is approved to manage any role on behalf of another user.
     /// @param _tokenAddress The token address.
-    /// @param _approver The user approving the operator.
     /// @param _operator The user approved to grant and revoke roles.
     /// @param _isApproved The approval status.
     event RoleApprovalForAll(
         address indexed _tokenAddress,
-        address indexed _approver,
         address indexed _operator,
         bool _isApproved
     );
@@ -63,13 +61,11 @@ interface IERC7432 is IERC165 {
     /// @notice Emitted when a user is approved to manage the roles of an NFT on behalf of another user.
     /// @param _tokenAddress The token address.
     /// @param _tokenId The token identifier.
-    /// @param _approver The user approving the operator.
     /// @param _operator The user approved to grant and revoke roles.
     /// @param _isApproved The approval status.
     event RoleApproval(
         address indexed _tokenAddress,
         uint256 indexed _tokenId,
-        address indexed _approver,
         address _operator,
         bool _isApproved
     );


### PR DESCRIPTION
This Pull Request introduces ERC-721 style approvals to ERC-7432.

The new functions and events enable users to approve other accounts to grant and revoke roles on its behalf. Users can authorize an account to manage a single NFT or any NFTs in a collection. This functionality was introduced to allow third-party contracts to interact with ERC-7432 without requiring ownership of the NFTs.

New Functions Added:
- `grantRoleFrom()` (Function to grant a role on behalf of a user).
- `revokeRoleFrom()` (Function to revoke a role on behalf of a user).
- `setRoleApprovalForAll()` (Function to approve an operator to manage any role on behalf of another user)
- `approveRole()` (Function to approve an operator to manage roles of a specific token Id on behalf of another user)

New Events Added: 
- `RoleApprovalForAll` (Event emitted when a user is approved to manage any role on behalf of another user).
- `RoleApproval` (Event emitted when a user is approved to manage the roles of a specific token Id on behalf of another user.)