### PR TITLE
Add role assignment struct and update eip

### DIFF
--- a/EIPS/eip-7432.md
+++ b/EIPS/eip-7432.md
@@ -207,10 +207,10 @@ interface IERC7432 /* is ERC165 */ {
         address _operator
     ) external view returns (bool);
 
-    /// @notice Returns the last grantee of a role.
-    /// @param _role The role.
+    /// @notice Returns the last user to receive a role.
+    /// @param _role The role identifier.
     /// @param _tokenAddress The token address.
-    /// @param _tokenId The token ID.
+    /// @param _tokenId The token identifier.
     /// @param _grantor The user that granted the role.
     function lastGrantee(
         bytes32 _role,
@@ -337,14 +337,15 @@ for complex tuple types.
 * Compliant contracts MUST implement the `IERC7432` interface.
 * A role is represented by a `bytes32`, and it's RECOMMENDED to use the `keccak256` of the role's name for this purpose:
   `bytes32 role = keccak256("ROLE_NAME")`.
-* The `grantRoleFrom` and `grantRevocableRoleFrom` function MUST revert if the `_expirationDate` is in the past or if the `msg.sender` is not approved
-  to grant roles on behalf of the `_grantor`. It MAY be implemented as `public` or `external`.
+* The `grantRoleFrom` and `grantRevocableRoleFrom` functions MUST revert if the `_expirationDate` is in the past or if
+  the `msg.sender` is not approved to grant roles on behalf of the `_grantor`. It MAY be implemented as `public` or
+ `external`.
 * The `revokeRole` and `revokeRoleFrom` functions SHOULD revert if `_revocable` is `false`. They MAY be implemented as `public` or `external`.
 * The `revokeRoleFrom` function MUST revert if the `msg.sender` is not approved to revoke roles on behalf of the `_revoker` or the `_grantee`.
   It MAY be implemented as `public` or `external`.
 * The `setRoleApprovalForAll` function MAY be implemented as `public` or `external`.
-* The `hasNonUniqueRole` function MAY be implemented as `pure` or `view` and SHOULD only confirm if the role assignment exists
-  and is not expired (supports simultaneous role assignments).
+* The `hasNonUniqueRole` function MAY be implemented as `pure` or `view` and SHOULD only confirm if the role assignment 
+  exists and is not expired.
 * The `hasRole` function MAY be implemented as `pure` or `view` and SHOULD check if the assignment exists, is not
   expired and is the last one granted (does not support simultaneous role assignments).
 * The `roleData` function MAY be implemented as `pure` or `view`, and SHOULD return an empty struct if the role
@@ -357,9 +358,9 @@ for complex tuple types.
 
 ## Rationale
 
-[ERC-7432](./eip-7432.md) IS NOT an extension of [ERC-721](./eip-721.md). The main reason
-behind this decision is to keep the standard agnostic of any NFT implementation. This approach also enables the standard
-to be implemented externally or on the same contract as the NFT, and allow dApps to use roles with immutable NFTs.
+[ERC-7432](./eip-7432.md) IS NOT an extension of [ERC-721](./eip-721.md). The main reason behind this decision is to
+keep the standard agnostic of any NFT implementation. This approach also enables the standard to be implemented
+externally or on the same contract as the NFT, and allow dApps to use roles with immutable NFTs.
 
 ### Automatic Expiration
 
@@ -383,8 +384,7 @@ allowing recipients to eliminate undesirable assignments.
 
 The standard supports both unique and non-unique roles. Unique roles can be assigned to only one account at a time,
 while non-unique roles can be granted to multiple accounts simultaneously. The roles extension metadata can be used to
-specify if roles are unique or not, and if the contract does not implement it, all roles should be considered
-non-unique.
+specify if roles are unique or not, and if the contract does not implement it, all roles should be considered unique.
 
 To verify the validity of a unique role, dApps SHOULD use the `hasRole` function, which also checks if no other
 assignment was granted afterward. In other words, for unique roles, each new assignment invalidates the previous one,
@@ -400,15 +400,17 @@ developers can integrate this information into their applications, both on-chain
 ### Role Approval
 
 Similar to [ERC-721](./eip-721.md), this standard enables users to approve other accounts to grant and revoke roles on
-its behalf. Users can authorize an account to manage all NFTs in a collection. This functionality was
-introduced to allow third-party contracts to interact with ERC-7432 without requiring ownership of the NFTs.
+its behalf. This functionality was introduced to allow third-parties to interact with ERC-7432 without requiring NFT
+ownership. Compliant contracts MUST implement the functions `setRoleApprovalForAll` and `isRoleApprovedForAll` to 
+deliver this feature. 
 
 ## Backwards Compatibility
 
 On all functions and events, the standard requires both the `tokenAddress` and `tokenId` to be provided. This 
 requirement enables dApps to use a standalone [ERC-7432](./eip-7432.md) contract as the authoritative source for the
-roles of immutable NFTs. It also helps with backward compatibility as NFT-specific functions such as `ownerOf`. Consequently, this design ensures a more straightforward integration with different
-implementations of NFTs.
+roles of immutable NFTs. It also helps with backward compatibility as NFT-specific functions such as `ownerOf` are no
+longer required. Consequently, this design ensures a more straightforward integration with different implementations of
+NFTs.
 
 ## Reference Implementation
 
@@ -422,8 +424,9 @@ Developers integrating the Non-Fungible Token Roles interface should consider th
 * Take into account potential attack vectors such as reentrancy and ensure appropriate safeguards are in place.
 * Since this standard does not check NFT ownership, it's the responsibility of the dApp to query for the NFT Owner and
   pass the correct `_grantor` to the `hasRole` function.
-* It's the responsibility of the dApp to check if the role is unique or non-unique. To ensure the role was assigned
-  to another account when non-unique, `hasNonUniqueRole` should be called instead of `hasRole`.
+* It's the responsibility of the dApp to confirm if the role is unique or non-unique. When the role is unique, the dApp
+  SHOULD use the `hasRole` function to check for the validity of the assignment. `hasNonUniqueRole` SHOULD be used when
+  the role can be granted to multiple accounts simultaneously (hence, non-unique).
 
 ## Copyright
 

--- a/EIPS/eip-7432.md
+++ b/EIPS/eip-7432.md
@@ -41,8 +41,23 @@ Compliant contracts MUST implement the following interface:
 ```solidity
 /// @title ERC-7432 Non-Fungible Token Roles
 /// @dev See https://eips.ethereum.org/EIPS/eip-7432
-/// Note: the ERC-165 identifier for this interface is 0x25be10b2.
+/// Note: the ERC-165 identifier for this interface is 0x17ef8677.
 interface IERC7432 /* is ERC165 */ {
+    struct RoleData {
+        uint64 expirationDate;
+        bool revocable;
+        bytes data;
+    }
+
+    struct RoleAssignment {
+        bytes32 role;
+        address tokenAddress;
+        uint256 tokenId;
+        address grantor;
+        address grantee;
+        uint64 expirationDate;
+        bytes data;
+    }
 
     /** Events **/
 
@@ -90,69 +105,15 @@ interface IERC7432 /* is ERC165 */ {
         bool _isApproved
     );
 
-    /// @notice Emitted when a user is approved to manage the roles of an NFT on behalf of another user.
-    /// @param _tokenAddress The token address.
-    /// @param _tokenId The token identifier.
-    /// @param _operator The user approved to grant and revoke roles.
-    /// @param _isApproved The approval status.
-    event RoleApproval(
-        address indexed _tokenAddress,
-        uint256 indexed _tokenId,
-        address _operator,
-        bool _isApproved
-    );
-
     /** External Functions **/
 
-    /// @notice Grants a role to a user.
-    /// @param _role The role identifier.
-    /// @param _tokenAddress The token address.
-    /// @param _tokenId The token identifier.
-    /// @param _grantee The user receiving the role.
-    /// @param _expirationDate The expiration date of the role.
-    /// @param _revocable Whether the role is revocable or not.
-    /// @param _data Any additional data about the role.
-    function grantRole(
-        bytes32 _role,
-        address _tokenAddress,
-        uint256 _tokenId,
-        address _grantee,
-        uint64 _expirationDate,
-        bool _revocable,
-        bytes calldata _data
-    ) external;
-
-    /// @notice Revokes a role from a user.
-    /// @param _role The role identifier.
-    /// @param _tokenAddress The token address.
-    /// @param _tokenId The token identifier.
-    /// @param _grantee The user that receives the role revocation.
-    function revokeRole(
-        bytes32 _role,
-        address _tokenAddress,
-        uint256 _tokenId,
-        address _grantee
-    ) external;
+    /// @notice Grants a role on behalf of a user.
+    /// @param _roleAssignment The role assignment data.
+    function grantRoleFrom(RoleAssignment calldata _roleAssignment) external;
 
     /// @notice Grants a role on behalf of a user.
-    /// @param _role The role identifier.
-    /// @param _tokenAddress The token address.
-    /// @param _tokenId The token identifier.
-    /// @param _grantor The user assigning the role.
-    /// @param _grantee The user that receives the role.
-    /// @param _expirationDate The expiration date of the role.
-    /// @param _revocable Whether the role is revocable or not.
-    /// @param _data Any additional data about the role.
-    function grantRoleFrom(
-        bytes32 _role,
-        address _tokenAddress,
-        uint256 _tokenId,
-        address _grantor,
-        address _grantee,
-        uint64 _expirationDate,
-        bool _revocable,
-        bytes calldata _data
-    ) external;
+    /// @param _roleAssignment The role assignment data.
+    function grantRevocableRoleFrom(RoleAssignment calldata _roleAssignment) external;
 
     /// @notice Revokes a role on behalf of a user.
     /// @param _role The role identifier.
@@ -178,18 +139,6 @@ interface IERC7432 /* is ERC165 */ {
         bool _approved
     ) external;
 
-    /// @notice Approves operator to grant and revoke roles of an NFT on behalf of another user.
-    /// @param _tokenAddress The token address.
-    /// @param _tokenId The token identifier.
-    /// @param _operator The user approved to grant and revoke roles.
-    /// @param _approved The approval status.
-    function approveRole(
-        address _tokenAddress,
-        uint256 _tokenId,
-        address _operator,
-        bool _approved
-    ) external;
-
     /** View Functions **/
 
     /// @notice Checks if a user has a role.
@@ -199,11 +148,11 @@ interface IERC7432 /* is ERC165 */ {
     /// @param _grantor The user that assigned the role.
     /// @param _grantee The user that received the role.
     function hasRole(
-      bytes32 _role,
-      address _tokenAddress,
-      uint256 _tokenId,
-      address _grantor,
-      address _grantee
+        bytes32 _role,
+        address _tokenAddress,
+        uint256 _tokenId,
+        address _grantor,
+        address _grantee
     ) external view returns (bool);
 
     /// @notice Checks if a user has a unique role.
@@ -213,11 +162,11 @@ interface IERC7432 /* is ERC165 */ {
     /// @param _grantor The user that assigned the role.
     /// @param _grantee The user that received the role.
     function hasUniqueRole(
-      bytes32 _role,
-      address _tokenAddress,
-      uint256 _tokenId,
-      address _grantor,
-      address _grantee
+        bytes32 _role,
+        address _tokenAddress,
+        uint256 _tokenId,
+        address _grantor,
+        address _grantee
     ) external view returns (bool);
 
     /// @notice Returns the custom data of a role assignment.
@@ -227,12 +176,12 @@ interface IERC7432 /* is ERC165 */ {
     /// @param _grantor The user that assigned the role.
     /// @param _grantee The user that received the role.
     function roleData(
-      bytes32 _role,
-      address _tokenAddress,
-      uint256 _tokenId,
-      address _grantor,
-      address _grantee
-    ) external view returns (bytes memory data_);
+        bytes32 _role,
+        address _tokenAddress,
+        uint256 _tokenId,
+        address _grantor,
+        address _grantee
+    ) external view returns (RoleData memory data_);
 
     /// @notice Returns the expiration date of a role assignment.
     /// @param _role The role identifier.
@@ -241,11 +190,11 @@ interface IERC7432 /* is ERC165 */ {
     /// @param _grantor The user that assigned the role.
     /// @param _grantee The user that received the role.
     function roleExpirationDate(
-      bytes32 _role,
-      address _tokenAddress,
-      uint256 _tokenId,
-      address _grantor,
-      address _grantee
+        bytes32 _role,
+        address _tokenAddress,
+        uint256 _tokenId,
+        address _grantor,
+        address _grantee
     ) external view returns (uint64 expirationDate_);
 
     /// @notice Checks if the grantor approved the operator for all NFTs.
@@ -253,23 +202,22 @@ interface IERC7432 /* is ERC165 */ {
     /// @param _grantor The user that approved the operator.
     /// @param _operator The user that can grant and revoke roles.
     function isRoleApprovedForAll(
-      address _tokenAddress,
-      address _grantor,
-      address _operator
-    ) external view returns (bool);
-
-    /// @notice Checks if the grantor approved the operator for a specific NFT.
-    /// @param _tokenAddress The token address.
-    /// @param _tokenId The token identifier.
-    /// @param _grantor The user that approved the operator.
-    /// @param _operator The user approved to grant and revoke roles.
-    function getApprovedRole(
         address _tokenAddress,
-        uint256 _tokenId,
         address _grantor,
         address _operator
     ) external view returns (bool);
 
+    /// @notice Returns the last grantee of a role.
+    /// @param _role The role.
+    /// @param _tokenAddress The token address.
+    /// @param _tokenId The token ID.
+    /// @param _grantor The user that granted the role.
+    function lastGrantee(
+        bytes32 _role,
+        address _tokenAddress,
+        uint256 _tokenId,
+        address _grantor
+    ) external view returns (address);
 }
 ```
 
@@ -389,32 +337,27 @@ for complex tuple types.
 * Compliant contracts MUST implement the `IERC7432` interface.
 * A role is represented by a `bytes32`, and it's RECOMMENDED to use the `keccak256` of the role's name for this purpose:
   `bytes32 role = keccak256("ROLE_NAME")`.
-* The `grantRole` function MUST revert if the `_expirationDate` is in the past, and MAY be implemented as `public` or
-  `external`.
-* The `grantRoleFrom` function MUST revert if the `_expirationDate` is in the past or if the `msg.sender` is not approved
+* The `grantRoleFrom` and `grantRevocableRoleFrom` function MUST revert if the `_expirationDate` is in the past or if the `msg.sender` is not approved
   to grant roles on behalf of the `_grantor`. It MAY be implemented as `public` or `external`.
 * The `revokeRole` and `revokeRoleFrom` functions SHOULD revert if `_revocable` is `false`. They MAY be implemented as `public` or `external`.
 * The `revokeRoleFrom` function MUST revert if the `msg.sender` is not approved to revoke roles on behalf of the `_revoker` or the `_grantee`.
   It MAY be implemented as `public` or `external`.
 * The `setRoleApprovalForAll` function MAY be implemented as `public` or `external`.
-* The `approveRole` function MAY be implemented as `public` or `external`.
 * The `hasRole` function MAY be implemented as `pure` or `view` and SHOULD only confirm if the role assignment exists
   and is not expired (supports simultaneous role assignments).
 * The `hasUniqueRole` function MAY be implemented as `pure` or `view` and SHOULD check if the assignment exists, is not
   expired and is the last one granted (does not support simultaneous role assignments).
-* The `roleData` function MAY be implemented as `pure` or `view`, and SHOULD return an empty array of bytes if the role
+* The `roleData` function MAY be implemented as `pure` or `view`, and SHOULD return an empty struct if the role
   assignment does not exist.
 * The `roleExpirationDate` function MAY be implemented as `pure` or `view`, and SHOULD return zero if the role
   assignment does not exist.
 * The `isRoleApprovedForAll` function MAY be implemented as `pure` or `view` and SHOULD only return `true` if the
   `_operator` is approved to grant and revoke roles for all NFTs on behalf of the `_grantor`.
-* The `getApprovedRole` function MAY be implemented as `pure` or `view` and SHOULD only return `true` if the `_operator`
-  is approved to grant and revoke roles for the specified NFT on behalf of the `_grantor`.
 * Compliant contracts SHOULD support [ERC-165](./eip-165.md).
 
 ## Rationale
 
-[ERC-7432](./eip-7432.md) IS NOT an extension of [ERC-721](./eip-721.md) or [ERC-1155](./eip-1155.md). The main reason
+[ERC-7432](./eip-7432.md) IS NOT an extension of [ERC-721](./eip-721.md). The main reason
 behind this decision is to keep the standard agnostic of any NFT implementation. This approach also enables the standard
 to be implemented externally or on the same contract as the NFT, and allow dApps to use roles with immutable NFTs.
 
@@ -457,15 +400,14 @@ developers can integrate this information into their applications, both on-chain
 ### Role Approval
 
 Similar to [ERC-721](./eip-721.md), this standard enables users to approve other accounts to grant and revoke roles on
-its behalf. Users can authorize an account to manage a single NFT or any NFTs in a collection. This functionality was
+its behalf. Users can authorize an account to manage all NFTs in a collection. This functionality was
 introduced to allow third-party contracts to interact with ERC-7432 without requiring ownership of the NFTs.
 
 ## Backwards Compatibility
 
 On all functions and events, the standard requires both the `tokenAddress` and `tokenId` to be provided. This 
 requirement enables dApps to use a standalone [ERC-7432](./eip-7432.md) contract as the authoritative source for the
-roles of immutable NFTs. It also helps with backward compatibility as NFT-specific functions such as `ownerOf` and
-`balanceOf` aren't required. Consequently, this design ensures a more straightforward integration with different
+roles of immutable NFTs. It also helps with backward compatibility as NFT-specific functions such as `ownerOf`. Consequently, this design ensures a more straightforward integration with different
 implementations of NFTs.
 
 ## Reference Implementation

--- a/EIPS/eip-7432.md
+++ b/EIPS/eip-7432.md
@@ -41,7 +41,7 @@ Compliant contracts MUST implement the following interface:
 ```solidity
 /// @title ERC-7432 Non-Fungible Token Roles
 /// @dev See https://eips.ethereum.org/EIPS/eip-7432
-/// Note: the ERC-165 identifier for this interface is 0x17ef8677.
+/// Note: the ERC-165 identifier for this interface is 0x04984ac8.
 interface IERC7432 /* is ERC165 */ {
     struct RoleData {
         uint64 expirationDate;
@@ -147,7 +147,7 @@ interface IERC7432 /* is ERC165 */ {
     /// @param _tokenId The token identifier.
     /// @param _grantor The user that assigned the role.
     /// @param _grantee The user that received the role.
-    function hasRole(
+    function hasNonUniqueRole(
         bytes32 _role,
         address _tokenAddress,
         uint256 _tokenId,
@@ -161,7 +161,7 @@ interface IERC7432 /* is ERC165 */ {
     /// @param _tokenId The token identifier.
     /// @param _grantor The user that assigned the role.
     /// @param _grantee The user that received the role.
-    function hasUniqueRole(
+    function hasRole(
         bytes32 _role,
         address _tokenAddress,
         uint256 _tokenId,
@@ -324,7 +324,7 @@ The following JSON is an example of [ERC-7432](./eip-7432.md) Metadata:
 
 The `roles` array properties are SUGGESTED, and developers should add any other relevant information as necessary (e.g.,
 an image for the role). However, it's highly RECOMMENDED to include the `isUniqueRole` property, as this field is
-used to determine if the `hasRole` or `hasUniqueRole` function should be called (refer to 
+used to determine if the `hasRole` or `hasNonUniqueRole` function should be called (refer to 
 [Unique and Non-Unique Roles](#unique-and-non-unique-roles)).
 
 It's also important to highlight the importance of the `inputs` property. This field describes the parameters that
@@ -343,9 +343,9 @@ for complex tuple types.
 * The `revokeRoleFrom` function MUST revert if the `msg.sender` is not approved to revoke roles on behalf of the `_revoker` or the `_grantee`.
   It MAY be implemented as `public` or `external`.
 * The `setRoleApprovalForAll` function MAY be implemented as `public` or `external`.
-* The `hasRole` function MAY be implemented as `pure` or `view` and SHOULD only confirm if the role assignment exists
+* The `hasNonUniqueRole` function MAY be implemented as `pure` or `view` and SHOULD only confirm if the role assignment exists
   and is not expired (supports simultaneous role assignments).
-* The `hasUniqueRole` function MAY be implemented as `pure` or `view` and SHOULD check if the assignment exists, is not
+* The `hasRole` function MAY be implemented as `pure` or `view` and SHOULD check if the assignment exists, is not
   expired and is the last one granted (does not support simultaneous role assignments).
 * The `roleData` function MAY be implemented as `pure` or `view`, and SHOULD return an empty struct if the role
   assignment does not exist.
@@ -386,7 +386,7 @@ while non-unique roles can be granted to multiple accounts simultaneously. The r
 specify if roles are unique or not, and if the contract does not implement it, all roles should be considered
 non-unique.
 
-To verify the validity of a unique role, dApps SHOULD use the `hasUniqueRole` function, which also checks if no other
+To verify the validity of a unique role, dApps SHOULD use the `hasRole` function, which also checks if no other
 assignment was granted afterward. In other words, for unique roles, each new assignment invalidates the previous one,
 and only the last one can be valid.
 
@@ -422,8 +422,8 @@ Developers integrating the Non-Fungible Token Roles interface should consider th
 * Take into account potential attack vectors such as reentrancy and ensure appropriate safeguards are in place.
 * Since this standard does not check NFT ownership, it's the responsibility of the dApp to query for the NFT Owner and
   pass the correct `_grantor` to the `hasRole` function.
-* It's the responsibility of the dApp to check if the role is unique or non-unique. To ensure the role was not assigned
-  to another account when unique, `hasUniqueRole` should be called instead of `hasRole`.
+* It's the responsibility of the dApp to check if the role is unique or non-unique. To ensure the role was assigned
+  to another account when non-unique, `hasNonUniqueRole` should be called instead of `hasRole`.
 
 ## Copyright
 

--- a/assets/eip-7432/ERC7432.sol
+++ b/assets/eip-7432/ERC7432.sol
@@ -12,10 +12,7 @@ contract ERC7432 is IERC7432 {
     // grantor => tokenAddress => tokenId => role => grantee
     mapping(address => mapping(address => mapping(uint256 => mapping(bytes32 => address)))) public latestGrantees;
 
-    // grantor => tokenAddress => tokenId => operator => isApproved
-    mapping(address => mapping(address => mapping(uint256 => mapping(address => bool)))) public tokenIdApprovals;
-
-    // grantor => tokenAddress => operator => isApproved
+    // grantor => operator => tokenAddress => isApproved
     mapping(address => mapping(address => mapping(address => bool))) public tokenApprovals;
 
     modifier validExpirationDate(uint64 _expirationDate) {
@@ -23,56 +20,34 @@ contract ERC7432 is IERC7432 {
         _;
     }
 
-    modifier onlyApproved(address _tokenAddress, uint256 _tokenId, address _account) {
+    modifier onlyAccountOrApproved(address _tokenAddress, address _account) {
         require(
-            _isRoleApproved(_tokenAddress, _tokenId, _account, msg.sender),
+            msg.sender == _account || isRoleApprovedForAll(_tokenAddress, _account, msg.sender),
             "ERC7432: sender must be approved"
         );
         _;
     }
 
-    function grantRole(
-        bytes32 _role,
-        address _tokenAddress,
-        uint256 _tokenId,
-        address _grantee,
-        uint64 _expirationDate,
-        bool _revocable,
-        bytes calldata _data
-    ) external {
-        _grantRole(_role, _tokenAddress, _tokenId, msg.sender, _grantee, _expirationDate, _revocable, _data);
+    function grantRevocableRoleFrom(RoleAssignment calldata _roleAssignment) override onlyAccountOrApproved(_roleAssignment.tokenAddress, _roleAssignment.grantor) external {
+        _grantRole(_roleAssignment, true);
     }
 
-    function grantRoleFrom(
-        bytes32 _role,
-        address _tokenAddress,
-        uint256 _tokenId,
-        address _grantor,
-        address _grantee,
-        uint64 _expirationDate,
-        bool _revocable,
-        bytes calldata _data
-    ) external override onlyApproved(_tokenAddress, _tokenId, _grantor) {
-        _grantRole(_role, _tokenAddress, _tokenId, _grantor, _grantee, _expirationDate, _revocable, _data);
+    function grantRoleFrom(RoleAssignment calldata _roleAssignment) external override onlyAccountOrApproved(_roleAssignment.tokenAddress, _roleAssignment.grantor) {
+        _grantRole(_roleAssignment, false);
     }
+
 
     function _grantRole(
-        bytes32 _role,
-        address _tokenAddress,
-        uint256 _tokenId,
-        address _grantor,
-        address _grantee,
-        uint64 _expirationDate,
-        bool _revocable,
-        bytes calldata _data
-    ) internal validExpirationDate(_expirationDate) {
-        roleAssignments[_grantor][_grantee][_tokenAddress][_tokenId][_role] = RoleData(_expirationDate, _revocable, _data);
-        latestGrantees[_grantor][_tokenAddress][_tokenId][_role] = _grantee;
-        emit RoleGranted(_role, _tokenAddress, _tokenId, _grantor, _grantee, _expirationDate, _revocable, _data);
-    }
-
-    function revokeRole(bytes32 _role, address _tokenAddress, uint256 _tokenId, address _grantee) external {
-        _revokeRole(_role, _tokenAddress, _tokenId, msg.sender, _grantee, msg.sender);
+        RoleAssignment memory _roleAssignment,
+        bool _revocable
+    ) internal validExpirationDate(_roleAssignment.expirationDate) {
+        roleAssignments[_roleAssignment.grantor][_roleAssignment.grantee][_roleAssignment.tokenAddress][
+            _roleAssignment.tokenId
+        ][_roleAssignment.role] = RoleData(_roleAssignment.expirationDate, _revocable, _roleAssignment.data);
+        latestGrantees[_roleAssignment.grantor][_roleAssignment.tokenAddress][_roleAssignment.tokenId][
+            _roleAssignment.role
+        ] = _roleAssignment.grantee;
+        emit RoleGranted(_roleAssignment.role, _roleAssignment.tokenAddress, _roleAssignment.tokenId, _roleAssignment.grantor, _roleAssignment.grantee, _roleAssignment.expirationDate, _revocable, _roleAssignment.data);
     }
 
     function revokeRoleFrom(
@@ -82,14 +57,14 @@ contract ERC7432 is IERC7432 {
         address _revoker,
         address _grantee
     ) external override {
-        address _caller = _getApprovedCaller(_tokenAddress, _tokenId, _revoker, _grantee);
+        address _caller = msg.sender == _revoker || msg.sender == _grantee ? msg.sender : _getApprovedCaller(_tokenAddress, _revoker, _grantee);
         _revokeRole(_role, _tokenAddress, _tokenId, _revoker, _grantee, _caller);
     }
 
-    function _getApprovedCaller(address _tokenAddress, uint256 _tokenId, address _revoker, address _grantee) internal view returns (address) {
-        if (_isRoleApproved(_tokenAddress, _tokenId, _grantee, msg.sender)) {
+    function _getApprovedCaller(address _tokenAddress, address _revoker, address _grantee) internal view returns (address) {
+        if(isRoleApprovedForAll(_tokenAddress, _grantee, msg.sender)){
             return _grantee;
-        } else if(_isRoleApproved(_tokenAddress, _tokenId, _revoker, msg.sender)){
+        } else if(isRoleApprovedForAll(_tokenAddress, _revoker, msg.sender)){
             return _revoker;
         } else {
             revert("ERC7432: sender must be approved");
@@ -137,10 +112,10 @@ contract ERC7432 is IERC7432 {
         uint256 _tokenId,
         address _grantor,
         address _grantee
-    ) external view returns (bytes memory data_) {
-        RoleData memory _roleData = roleAssignments[_grantor][_grantee][_tokenAddress][_tokenId][_role];
-        return (_roleData.data);
+    ) external view returns (RoleData memory) {
+        return roleAssignments[_grantor][_grantee][_tokenAddress][_tokenId][_role];
     }
+
 
     function roleExpirationDate(
         bytes32 _role,
@@ -149,8 +124,7 @@ contract ERC7432 is IERC7432 {
         address _grantor,
         address _grantee
     ) external view returns (uint64 expirationDate_) {
-        RoleData memory _roleData = roleAssignments[_grantor][_grantee][_tokenAddress][_tokenId][_role];
-        return (_roleData.expirationDate);
+        return roleAssignments[_grantor][_grantee][_tokenAddress][_tokenId][_role].expirationDate;
     }
 
     function supportsInterface(bytes4 interfaceId) external view virtual override returns (bool) {
@@ -166,16 +140,6 @@ contract ERC7432 is IERC7432 {
         emit RoleApprovalForAll(_tokenAddress, _operator, _isApproved);
     }
 
-    function approveRole(
-        address _tokenAddress,
-        uint256 _tokenId,
-        address _operator,
-        bool _approved
-    ) external override {
-        tokenIdApprovals[msg.sender][_tokenAddress][_tokenId][_operator] = _approved;
-        emit RoleApproval(_tokenAddress, _tokenId, _operator, _approved);
-    }
-
     function isRoleApprovedForAll(
         address _tokenAddress,
         address _grantor,
@@ -184,21 +148,12 @@ contract ERC7432 is IERC7432 {
         return tokenApprovals[_grantor][_tokenAddress][_operator];
     }
 
-    function getApprovedRole(
+    function lastGrantee(
+        bytes32 _role,
         address _tokenAddress,
         uint256 _tokenId,
-        address _grantor,
-        address _operator
-    ) public view override returns (bool) {
-        return tokenIdApprovals[_grantor][_tokenAddress][_tokenId][_operator];
-    }
-
-    function _isRoleApproved(
-        address _tokenAddress,
-        uint256 _tokenId,
-        address _grantor,
-        address _operator
-    ) internal view returns (bool) {
-        return isRoleApprovedForAll(_tokenAddress, _grantor, _operator) || getApprovedRole(_tokenAddress, _tokenId, _grantor, _operator);
+        address _grantor
+    ) public view override returns (address) {
+        return latestGrantees[_grantor][_tokenAddress][_tokenId][_role];
     }
 }

--- a/assets/eip-7432/ERC7432.sol
+++ b/assets/eip-7432/ERC7432.sol
@@ -62,9 +62,9 @@ contract ERC7432 is IERC7432 {
     }
 
     function _getApprovedCaller(address _tokenAddress, address _revoker, address _grantee) internal view returns (address) {
-        if(isRoleApprovedForAll(_tokenAddress, _grantee, msg.sender)){
+        if (isRoleApprovedForAll(_tokenAddress, _grantee, msg.sender)) {
             return _grantee;
-        } else if(isRoleApprovedForAll(_tokenAddress, _revoker, msg.sender)){
+        } else if (isRoleApprovedForAll(_tokenAddress, _revoker, msg.sender)) {
             return _revoker;
         } else {
             revert("ERC7432: sender must be approved");

--- a/assets/eip-7432/interfaces/IERC7432.sol
+++ b/assets/eip-7432/interfaces/IERC7432.sol
@@ -6,7 +6,7 @@ import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol
 
 /// @title ERC-7432 Non-Fungible Token Roles
 /// @dev See https://eips.ethereum.org/EIPS/eip-7432
-/// Note: the ERC-165 identifier for this interface is 0x17ef8677.
+/// Note: the ERC-165 identifier for this interface is 0x04984ac8.
 interface IERC7432 is IERC165 {
     struct RoleData {
         uint64 expirationDate;
@@ -112,7 +112,7 @@ interface IERC7432 is IERC165 {
     /// @param _tokenId The token identifier.
     /// @param _grantor The user that assigned the role.
     /// @param _grantee The user that received the role.
-    function hasRole(
+    function hasNonUniqueRole(
         bytes32 _role,
         address _tokenAddress,
         uint256 _tokenId,
@@ -126,7 +126,7 @@ interface IERC7432 is IERC165 {
     /// @param _tokenId The token identifier.
     /// @param _grantor The user that assigned the role.
     /// @param _grantee The user that received the role.
-    function hasUniqueRole(
+    function hasRole(
         bytes32 _role,
         address _tokenAddress,
         uint256 _tokenId,

--- a/assets/eip-7432/interfaces/IERC7432.sol
+++ b/assets/eip-7432/interfaces/IERC7432.sol
@@ -6,11 +6,21 @@ import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol
 
 /// @title ERC-7432 Non-Fungible Token Roles
 /// @dev See https://eips.ethereum.org/EIPS/eip-7432
-/// Note: the ERC-165 identifier for this interface is 0x25be10b2.
+/// Note: the ERC-165 identifier for this interface is 0x17ef8677.
 interface IERC7432 is IERC165 {
     struct RoleData {
         uint64 expirationDate;
         bool revocable;
+        bytes data;
+    }
+
+    struct RoleAssignment {
+        bytes32 role;
+        address tokenAddress;
+        uint256 tokenId;
+        address grantor;
+        address grantee;
+        uint64 expirationDate;
         bytes data;
     }
 
@@ -60,69 +70,15 @@ interface IERC7432 is IERC165 {
         bool _isApproved
     );
 
-    /// @notice Emitted when a user is approved to manage the roles of an NFT on behalf of another user.
-    /// @param _tokenAddress The token address.
-    /// @param _tokenId The token identifier.
-    /// @param _operator The user approved to grant and revoke roles.
-    /// @param _isApproved The approval status.
-    event RoleApproval(
-        address indexed _tokenAddress,
-        uint256 indexed _tokenId,
-        address _operator,
-        bool _isApproved
-    );
-
     /** External Functions **/
 
-    /// @notice Grants a role to a user.
-    /// @param _role The role identifier.
-    /// @param _tokenAddress The token address.
-    /// @param _tokenId The token identifier.
-    /// @param _grantee The user receiving the role.
-    /// @param _expirationDate The expiration date of the role.
-    /// @param _revocable Whether the role is revocable or not.
-    /// @param _data Any additional data about the role.
-    function grantRole(
-        bytes32 _role,
-        address _tokenAddress,
-        uint256 _tokenId,
-        address _grantee,
-        uint64 _expirationDate,
-        bool _revocable,
-        bytes calldata _data
-    ) external;
-
-    /// @notice Revokes a role from a user.
-    /// @param _role The role identifier.
-    /// @param _tokenAddress The token address.
-    /// @param _tokenId The token identifier.
-    /// @param _grantee The user that receives the role revocation.
-    function revokeRole(
-        bytes32 _role,
-        address _tokenAddress,
-        uint256 _tokenId,
-        address _grantee
-    ) external;
+    /// @notice Grants a role on behalf of a user.
+    /// @param _roleAssignment The role assignment data.
+    function grantRoleFrom(RoleAssignment calldata _roleAssignment) external;
 
     /// @notice Grants a role on behalf of a user.
-    /// @param _role The role identifier.
-    /// @param _tokenAddress The token address.
-    /// @param _tokenId The token identifier.
-    /// @param _grantor The user assigning the role.
-    /// @param _grantee The user that receives the role.
-    /// @param _expirationDate The expiration date of the role.
-    /// @param _revocable Whether the role is revocable or not.
-    /// @param _data Any additional data about the role.
-    function grantRoleFrom(
-        bytes32 _role,
-        address _tokenAddress,
-        uint256 _tokenId,
-        address _grantor,
-        address _grantee,
-        uint64 _expirationDate,
-        bool _revocable,
-        bytes calldata _data
-    ) external;
+    /// @param _roleAssignment The role assignment data.
+    function grantRevocableRoleFrom(RoleAssignment calldata _roleAssignment) external;
 
     /// @notice Revokes a role on behalf of a user.
     /// @param _role The role identifier.
@@ -144,18 +100,6 @@ interface IERC7432 is IERC165 {
     /// @param _approved The approval status.
     function setRoleApprovalForAll(
         address _tokenAddress,
-        address _operator,
-        bool _approved
-    ) external;
-
-    /// @notice Approves operator to grant and revoke roles of an NFT on behalf of another user.
-    /// @param _tokenAddress The token address.
-    /// @param _tokenId The token identifier.
-    /// @param _operator The user approved to grant and revoke roles.
-    /// @param _approved The approval status.
-    function approveRole(
-        address _tokenAddress,
-        uint256 _tokenId,
         address _operator,
         bool _approved
     ) external;
@@ -202,7 +146,7 @@ interface IERC7432 is IERC165 {
         uint256 _tokenId,
         address _grantor,
         address _grantee
-    ) external view returns (bytes memory data_);
+    ) external view returns (RoleData memory data_);
 
     /// @notice Returns the expiration date of a role assignment.
     /// @param _role The role identifier.
@@ -228,15 +172,15 @@ interface IERC7432 is IERC165 {
         address _operator
     ) external view returns (bool);
 
-    /// @notice Checks if the grantor approved the operator for a specific NFT.
+    /// @notice Returns the last grantee of a role.
+    /// @param _role The role.
     /// @param _tokenAddress The token address.
-    /// @param _tokenId The token identifier.
-    /// @param _grantor The user that approved the operator.
-    /// @param _operator The user approved to grant and revoke roles.
-    function getApprovedRole(
+    /// @param _tokenId The token ID.
+    /// @param _grantor The user that granted the role.
+    function lastGrantee(
+        bytes32 _role,
         address _tokenAddress,
         uint256 _tokenId,
-        address _grantor,
-        address _operator
-    ) external view returns (bool);
+        address _grantor
+    ) external view returns (address);
 }

--- a/assets/eip-7432/interfaces/IERC7432.sol
+++ b/assets/eip-7432/interfaces/IERC7432.sol
@@ -172,10 +172,10 @@ interface IERC7432 is IERC165 {
         address _operator
     ) external view returns (bool);
 
-    /// @notice Returns the last grantee of a role.
-    /// @param _role The role.
+    /// @notice Returns the last user to receive a role.
+    /// @param _role The role identifier.
     /// @param _tokenAddress The token address.
-    /// @param _tokenId The token ID.
+    /// @param _tokenId The token identifier.
     /// @param _grantor The user that granted the role.
     function lastGrantee(
         bytes32 _role,


### PR DESCRIPTION
This pull request introduces several enhancements and modifications to the existing EIP. The key changes are as follows:

- The hasRole function has been modified to support checking for unique roles instead of non-unique.
- The new hasNonUniqueRole function has been added to facilitate checking multiple role assignments.
- The grantRole and revokeRole functions have been removed.
- The grantRevocableRoleFrom function has been added.
- The roleData function now returns all RoleData structs instead of only custom bytes data.
- Approvals at the tokenId level have been removed to simplify the approval process. Only approveForAll at the contract level is retained.
- The new lastGrantee function has been added to return the last grantee address of a role.